### PR TITLE
PortPorfile's operator==() must be const

### DIFF
--- a/include/RTnoProxy/RTnoProfile.h
+++ b/include/RTnoProxy/RTnoProfile.h
@@ -30,7 +30,7 @@ namespace ssr {
       return m_PortName;
     }
 
-    const bool operator==(const PortProfile& p) {
+    const bool operator==(const PortProfile& p) const {
       return (getPortName() == p.getPortName());
     }
   };


### PR DESCRIPTION
The newer C++ compiler (tested on VS2019) does not allow non-const PortProfile::operator==().

## Identify the Bug

Originally, the operator==() function should be a const function.
If this function is a non-const, at the time of instantiating PortProfileList(=std::list<PortProfile>), in the part comparing between const objects (std::list::remove etc.) , an error will occur because operator==() for the const object is not defined.
With recent C++ compilers, such a contradiction cannot be tolerated and an error occurs, so it is necessary to correct it.

## Description of the Change

"PortProfile::operator==()" in RTnoProfile.h has been chaged into "PortProfile::operator==() const".

## Verification 

Tested on the following environment
- Windows 10
- Visual Studio 2019
- OpenRTM-aist-1.2.1


